### PR TITLE
Add support for channel

### DIFF
--- a/pyvisa-sim/channels.py
+++ b/pyvisa-sim/channels.py
@@ -1,0 +1,181 @@
+# -*- coding: utf-8 -*-
+"""
+    pyvisa-sim.channel
+    ~~~~~~~~~~~~~~~~~~
+
+    Classes to enable the use of channels in devices.
+
+    :copyright: 2014 by PyVISA-sim Authors, see AUTHORS for more details.
+    :license: MIT, see LICENSE for more details.
+"""
+from collections import defaultdict
+
+import stringparser
+
+from .common import logger
+from .component import Component, Property, to_bytes
+
+
+class ChannelProperty(Property):
+    """A channel property storing the value for all channels.
+
+    """
+    def __init__(self, channel, name, default_value, specs):
+
+        #: Refrence to the channel holding that property.
+        self._channel = channel
+
+        super(ChannelProperty, self).__init__(name, default_value, specs)
+
+    def init_value(self, string_value):
+        """Create an empty defaultdict holding the default value.
+
+        """
+        value = self.validate_value(string_value)
+        self._value = defaultdict(lambda: value)
+
+    def get_value(self):
+        """Get the current value for a channel.
+
+        """
+        return self._value[self._channel._selected]
+
+    def set_value(self, string_value):
+        """Set the current value for a channel.
+
+        """
+        value = self.validate_value(string_value)
+        self._value[self._channel._selected] = value
+
+
+class ChDict(dict):
+    """Default dict like creating specialized sommand sets for a channel.
+
+    """
+    def __missing__(self, key):
+        """Create a channel specialized version of the mapping found in
+        __default__.
+
+        """
+        return {k.format(ch_id=key): v for k, v in self['__default__'].items()}
+
+
+class Channels(Component):
+    """A component representing a device channels.
+
+    """
+
+    def __init__(self, device, ids, can_select):
+
+        super(Channels, self).__init__()
+
+        #: Flag indicating whether or not the channel can be selected inside
+        #: the query or if it is pre-selected by a previous command.
+        self.can_select = can_select
+
+        #: Currently active channel, this can either reflect the currently
+        #: selected channel on the device or the currently inspected possible
+        #: when attempting to match.
+        self._selected = None
+
+        #: Reference to the parent device from which we might need to query and
+        #: set the current selected channel
+        self._device = device
+
+        #: Ids of the activated channels.
+        self._ids = ids
+
+        self._getters = ChDict(__default__={})
+
+        self._dialogues = ChDict(__default__={})
+
+    def add_dialogue(self, query, response):
+        """Add dialogue to channel.
+
+        :param query: query string
+        :param response: response string
+        """
+        self._dialogues['__default__'][to_bytes(query)] = to_bytes(response)
+
+    def add_property(self, name, default_value, getter_pair, setter_triplet,
+                     specs):
+        """Add property to channel
+
+        :param name: property name
+        :param default_value: default value as string
+        :param getter_pair: (query, response)
+        :param setter_triplet: (query, response, error)
+        :param specs: specification of the Property
+        """
+        self._properties[name] = ChannelProperty(self, name,
+                                                 default_value, specs)
+
+        query, response = getter_pair
+        self._getters['__default__'][to_bytes(query)] = name, response
+
+        query, response, error = setter_triplet
+        self._setters.append((name,
+                              stringparser.Parser(query),
+                              to_bytes(response),
+                              to_bytes(error)))
+
+    def match(self, query):
+        """Try to find a match for a query in the channel commands.
+
+        """
+        if not self.can_select:
+            ch_id = self._device._properties['selected_channel'].get_value()
+            if ch_id in self._ids:
+                self._selected = ch_id
+            else:
+                return
+
+            response = self._match_dialog(query,
+                                          self._dialogues['__default__'])
+            if response is not None:
+                return response
+
+            response = self._match_getters(query,
+                                           self._getters['__default__'])
+            if response is not None:
+                return response
+
+        else:
+            for ch_id in self._ids:
+                self._selected = ch_id
+                response = self._match_dialog(query,
+                                              self._dialogues[ch_id])
+                if response is not None:
+                    return response
+
+                response = self._match_getters(query,
+                                               self._getters[ch_id])
+                if response is not None:
+                    return response
+
+        return self._match_setters(query)
+
+    def _match_setters(self, query):
+        """Try to find a match
+        """
+        q = query.decode('utf-8')
+        for name, parser, response, error_response in self._setters:
+            try:
+                parsed = parser(q)
+                logger.debug('Found response in setter of %s' % name)
+            except ValueError:
+                continue
+
+            try:
+                if isinstance(parsed, dict) and 'ch_id' in parsed:
+                    self._selected = parsed['ch_id']
+                    self._properties[name].set_value(parsed['0'])
+                else:
+                    self._properties[name].set_value(parsed)
+                return response
+            except ValueError:
+                if isinstance(error_response, bytes):
+                    return error_response
+                return self._device.error_response('command_error')
+
+        return None

--- a/pyvisa-sim/component.py
+++ b/pyvisa-sim/component.py
@@ -1,0 +1,215 @@
+# -*- coding: utf-8 -*-
+"""
+    pyvisa-sim.component
+    ~~~~~~~~~~~~~~~~~~~~
+
+    Base classes for devices parts.
+
+    :copyright: 2014 by PyVISA-sim Authors, see AUTHORS for more details.
+    :license: MIT, see LICENSE for more details.
+"""
+import stringparser
+
+from .common import logger
+
+
+def to_bytes(val):
+    """Takes a text message and return a tuple
+    """
+    if val is NoResponse:
+        return val
+    val = val.replace('\\r', '\r').replace('\\n', '\n')
+    return val.encode()
+
+
+# Sentinel used for when there should not be a response to a query
+NoResponse = object()
+
+
+class Property(object):
+    """A device property
+    """
+
+    def __init__(self, name, value, specs):
+        """
+        :param name: name of the property
+        :param value: default value
+        :param specs: specification dictionary
+        :return:
+        """
+
+        t = specs.get('type', None)
+        if t:
+            for key, val in (('float', float), ('int', int), ('str', str)):
+                if t == key:
+                    t = specs['type'] = val
+                    break
+
+        for key in ('min', 'max'):
+            if key in specs:
+                specs[key] = t(specs[key])
+
+        if 'valid' in specs:
+            specs['valid'] = set([t(val) for val in specs['valid']])
+
+        self.name = name
+        self.specs = specs
+        self._value = None
+        self.init_value(value)
+
+    def init_value(self, string_value):
+        """Initialize the value hold by the Property.
+
+        """
+        self.set_value(string_value)
+
+    def get_value(self):
+        """Return the value stored by the Property.
+
+        """
+        return self._value
+
+    def set_value(self, string_value):
+        """Set the value
+        """
+        self._value = self.validate_value(string_value)
+
+    def validate_value(self, string_value):
+        """Validate that a value match the Property specs.
+
+        """
+        specs = self.specs
+        if 'type' in specs:
+            value = specs['type'](string_value)
+        else:
+            value = string_value
+        if 'min' in specs and value < specs['min']:
+            raise ValueError
+        if 'max' in specs and value > specs['max']:
+            raise ValueError
+        if 'valid' in specs and value not in specs['valid']:
+            raise ValueError
+        return value
+
+
+class Component(object):
+    """A component of a device.
+
+    """
+
+    def __init__(self):
+
+        #: Stores the queries accepted by the device.
+        #: query: response
+        #: :type: dict[bytes, bytes]
+        self._dialogues = {}
+
+        #: Maps property names to value, type, validator
+        #: :type: dict[str, Property]
+        self._properties = {}
+
+        #: Stores the getter queries accepted by the device.
+        #: query: (property_name, response)
+        #: :type: dict[bytes, (str, str)]
+        self._getters = {}
+
+        #: Stores the setters queries accepted by the device.
+        #: (property_name, string parser query, response, error response)
+        #: :type: list[(str, stringparser.Parser, bytes, bytes)]
+        self._setters = []
+
+    def add_dialogue(self, query, response):
+        """Add dialogue to device.
+
+        :param query: query string
+        :param response: response string
+        """
+        self._dialogues[to_bytes(query)] = to_bytes(response)
+
+    def add_property(self, name, default_value, getter_pair, setter_triplet,
+                     specs):
+        """Add property to device
+
+        :param name: property name
+        :param default_value: default value as string
+        :param getter_pair: (query, response)
+        :param setter_triplet: (query, response, error)
+        :param specs: specification of the Property
+        """
+        self._properties[name] = Property(name, default_value, specs)
+
+        query, response = getter_pair
+        self._getters[to_bytes(query)] = name, response
+
+        query, response, error = setter_triplet
+        self._setters.append((name,
+                              stringparser.Parser(query),
+                              to_bytes(response),
+                              to_bytes(error)))
+
+    def match(self, query):
+        """Try to find a match for a query in the instrument commands.
+
+        """
+        raise NotImplementedError()
+
+    def _match_dialog(self, query, dialogues=None):
+        """Tries to match in dialogues
+
+        :param query: message tuple
+        :type query: Tuple[bytes]
+        :return: response if found or None
+        :rtype: Tuple[bytes] | None
+        """
+        if dialogues is None:
+            dialogues = self._dialogues
+
+        # Try to match in the queries
+        if query in dialogues:
+            response = dialogues[query]
+            logger.debug('Found response in queries: %s' % repr(response))
+
+            return response
+
+    def _match_getters(self, query, getters=None):
+        """Tries to match in getters
+
+        :param query: message tuple
+        :type query: Tuple[bytes]
+        :return: response if found or None
+        :rtype: Tuple[bytes] | None
+        """
+        if getters is None:
+            getters = self._getters
+
+        if query in getters:
+            name, response = getters[query]
+            logger.debug('Found response in getter of %s' % name)
+            response = response.format(self._properties[name].get_value())
+            return response.encode('utf-8')
+
+    def _match_setters(self, query):
+        """Tries to match in setters
+
+        :param query: message tuple
+        :type query: Tuple[bytes]
+        :return: response if found or None
+        :rtype: Tuple[bytes] | None
+        """
+        q = query.decode('utf-8')
+        for name, parser, response, error_response in self._setters:
+            try:
+                value = parser(q)
+                logger.debug('Found response in setter of %s' % name)
+            except ValueError:
+                continue
+
+            try:
+                self._properties[name].set_value(value)
+                return response
+            except ValueError:
+                if isinstance(error_response, bytes):
+                    return error_response
+                return self.error_response('command_error')
+
+        return None

--- a/pyvisa-sim/devices.py
+++ b/pyvisa-sim/devices.py
@@ -9,81 +9,14 @@
     :license: MIT, see LICENSE for more details.
 """
 
-import stringparser
-
 from pyvisa import constants, rname
 
 from .common import logger
-
-
-def to_bytes(val):
-    """Takes a text message and return a tuple
-    """
-    if val is NoResponse:
-        return val
-    val = val.replace('\\r', '\r').replace('\\n', '\n')
-    return val.encode()
-
-
-# Sentinel used for when there should not be a response to a query
-NoResponse = object()
-
-
-class Property(object):
-    """A device property
-    """
-
-    _value = None
-
-    def __init__(self, name, value, specs):
-        """
-        :param name: name of the property
-        :param value: default value
-        :param specs: specification dictionary
-        :return:
-        """
-
-        t = specs.get('type', None)
-        if t:
-            for key, val in (('float', float), ('int', int), ('str', str)):
-                if t == key:
-                    t = specs['type'] = val
-                    break
-
-        for key in ('min', 'max'):
-            if key in specs:
-                specs[key] = t(specs[key])
-
-        if 'valid' in specs:
-            specs['valid'] = set([t(val) for val in specs['valid']])
-
-        self.name = name
-        self.specs = specs
-        self.set_value(value)
-
-    @property
-    def value(self):
-        return self._value
-
-    def set_value(self, string_value):
-        """Set the value
-        """
-        specs = self.specs
-        if 'type' in specs:
-            value = specs['type'](string_value)
-        else:
-            value = string_value
-        if 'min' in specs and value < specs['min']:
-            raise ValueError
-        if 'max' in specs and value > specs['max']:
-            raise ValueError
-        if 'valid' in specs and value not in specs['valid']:
-            raise ValueError
-        self._value = value
+from .component import to_bytes, Component, NoResponse
 
 
 class StatusRegister(object):
-    
+
     def __init__(self, values):
         object.__init__(self)
         self._value = 0
@@ -92,7 +25,7 @@ class StatusRegister(object):
             if name == 'q':
                 continue
             self._error_map[name] = int(value)
-    
+
     def set(self, error_key):
         self._value = self._value | self._error_map[error_key]
 
@@ -102,12 +35,12 @@ class StatusRegister(object):
     @property
     def value(self):
         return to_bytes(str(self._value))
-    
+
     def clear(self):
         self._value = 0
 
 
-class Device(object):
+class Device(Component):
     """A representation of a responsive device
 
     :param name: The identification name of the device
@@ -127,10 +60,18 @@ class Device(object):
     # :type: bytes
     _response_eom = None
 
-    def __init__(self, name):
+    def __init__(self, name, delimiter):
 
-        # Name of the device.
+        super(Device, self).__init__()
+
+        #: Name of the device.
         self.name = name
+
+        #: Special character use to delimit multiple messages.
+        self.delimiter = delimiter
+
+        #: Mapping between a name and a Channels object
+        self._channels = {}
 
         #: Stores the error response for each query accepted by the device.
         #: :type: dict[bytes, bytes | NoResponse]
@@ -147,25 +88,6 @@ class Device(object):
         #: TYPE CLASS -> (query termination, response termination)
         #: :type: dict[(pyvisa.constants.InterfaceType, str), (str, str)]
         self._eoms = {}
-
-        #: Stores the queries accepted by the device.
-        #: query: (response, error response)
-        #: :type: dict[bytes, bytes]
-        self._dialogues = {}
-
-        #: Maps property names to value, type, validator
-        #: :type: dict[str, Property]
-        self._properties = {}
-
-        #: Stores the getter queries accepted by the device.
-        #: query: (property_name, response)
-        #: :type: dict[bytes, (str, str)]
-        self._getters = {}
-
-        #: Stores the setters queries accepted by the device.
-        #: (property_name, string parser query, response, error response)
-        #: :type: list[(str, stringparser.Parser, bytes, bytes)]
-        self._setters = []
 
         #: Buffer in which the user can read
         #: :type: bytearray
@@ -185,8 +107,14 @@ class Device(object):
     def resource_name(self, value):
         p = rname.parse_resource_name(value)
         self._resource_name = str(p)
-        self._query_eom, self._response_eom = self._eoms[(p.interface_type_const,
-                                                          p.resource_class)]
+        self._query_eom, self._response_eom =\
+            self._eoms[(p.interface_type_const, p.resource_class)]
+
+    def add_channels(self, ch_name, ch_obj):
+        """Add a channel definition.
+
+        """
+        self._channels[ch_name] = ch_obj
 
     def add_error_handler(self, error_input):
         """Add error handler to the device
@@ -214,39 +142,11 @@ class Device(object):
 
         for key, value in response_dict.items():
             self._error_response[key] = to_bytes(value)
-    
+
     def error_response(self, error_key):
         if error_key in self._error_map:
             self._error_map[error_key].set(error_key)
         return self._error_response.get(error_key)
-
-    def add_dialogue(self, query, response):
-        """Add dialogue to device.
-
-        :param query: query string
-        :param response: response string
-        """
-        self._dialogues[to_bytes(query)] = to_bytes(response)
-
-    def add_property(self, name, default_value, getter_pair, setter_triplet, specs):
-        """Add property to device
-
-        :param name: property name
-        :param default_value: default value as string
-        :param getter_pair: (query, response)
-        :param setter_triplet: (query, response, error)
-        :param specs: specification of the Property
-        """
-        self._properties[name] = Property(name, default_value, specs)
-
-        query, response = getter_pair
-        self._getters[to_bytes(query)] = name, response
-
-        query, response, error = setter_triplet
-        self._setters.append((name,
-                              stringparser.Parser(query),
-                              to_bytes(response),
-                              to_bytes(error)))
 
     def add_eom(self, type_class, query_termination, response_termination):
         """Add default end of message for a given interface type and resource class.
@@ -256,9 +156,11 @@ class Device(object):
         :param response_termination: end of message used in responses.
         """
         interface_type, resource_class = type_class.split(' ')
-        interface_type = getattr(constants.InterfaceType, interface_type.lower())
-        self._eoms[(interface_type, resource_class)] = (to_bytes(query_termination),
-                                                        to_bytes(response_termination))
+        interface_type = getattr(constants.InterfaceType,
+                                 interface_type.lower())
+        self._eoms[(interface_type,
+                    resource_class)] = (to_bytes(query_termination),
+                                        to_bytes(response_termination))
 
     def write(self, data):
         """Write data into the device input buffer.
@@ -271,7 +173,8 @@ class Device(object):
             raise TypeError('data must be an instance of bytes')
 
         if len(data) != 1:
-            raise ValueError('data must have a length of 1, not %d' % len(data))
+            msg = 'data must have a length of 1, not %d'
+            raise ValueError(msg % len(data))
 
         self._input_buffer.extend(data)
 
@@ -280,84 +183,86 @@ class Device(object):
             return
 
         try:
-            query = bytes(self._input_buffer[:-l])
-            response = self._match(query)
-            eom = self._response_eom
+            message = bytes(self._input_buffer[:-l])
+            queries = (message.split(self.delimiter) if self.delimiter
+                       else [message])
+            for query in queries:
+                response = self._match(query)
+                eom = self._response_eom
 
-            if response is None:
-                response = self.error_response('command_error')
+                if response is None:
+                    response = self.error_response('command_error')
 
-            if response is not NoResponse:
-                self._output_buffer.extend(response)
-                self._output_buffer.extend(eom)
+                if response is not NoResponse:
+                    self._output_buffer.extend(response)
+                    self._output_buffer.extend(eom)
 
         finally:
             self._input_buffer = bytearray()
 
+    def read(self):
+        """Return a single byte from the output buffer
+        """
+        if self._output_buffer:
+            b, self._output_buffer = (self._output_buffer[0:1],
+                                      self._output_buffer[1:])
+            return b
+
+        return b''
+
     def _match(self, query):
-        """Tries to match in dialogues, getters and setters
+        """Tries to match in dialogues, getters and setters and subcomponents
 
         :param query: message tuple
         :type query: Tuple[bytes]
         :return: response if found or None
         :rtype: Tuple[bytes] | None
         """
-
-        # Try to match in the queries
-        if query in self._dialogues:
-            response = self._dialogues[query]
-            logger.debug('Found response in queries: %s' % repr(response))
-
+        response = self._match_dialog(query)
+        if response is not None:
             return response
 
-        # Now in the getters
-        if query in self._getters:
-            name, response = self._getters[query]
-            logger.debug('Found response in getter of %s' % name)
+        response = self._match_getters(query)
+        if response is not None:
+            return response
 
-            return response.format(self._properties[name].value).encode('utf-8')
+        response = self._match_registers(query)
+        if response is not None:
+            return response
 
-        # Try to match in the status registers
+        response = self._match_setters(query)
+        if response is not None:
+            return response
+
+        if response is None:
+            for channel in self._channels.values():
+                response = channel.match(query)
+                if response:
+                    return response
+
+        return None
+
+    def _match_registers(self, query):
+        """Tries to match in status registers
+
+        :param query: message tuple
+        :type query: Tuple[bytes]
+        :return: response if found or None
+        :rtype: Tuple[bytes] | None
+        """
         if query in self._status_registers:
             register = self._status_registers[query]
             response = register.value
-            logger.debug('Found response in status register: %s' % repr(response))
+            logger.debug('Found response in status register: %s',
+                         repr(response))
             register.clear()
 
             return response
 
-        q = query.decode('utf-8')
-
-        # Finally in the setters, this will be slow.
-        for name, parser, response, error_response in self._setters:
-            try:
-                value = parser(q)
-                logger.debug('Found response in setter of %s' % name)
-            except ValueError:
-                continue
-
-            try:
-                self._properties[name].set_value(value)
-                return response
-            except ValueError:
-                if isinstance(error_response, bytes):
-                    return error_response
-                return self.error_response('command_error')
-
-        return None
-
-    def read(self):
-        """Return a single byte from the output buffer
-        """
-        if self._output_buffer:
-            b, self._output_buffer = self._output_buffer[0:1], self._output_buffer[1:]
-            return b
-
-        return b''
-
 
 class Devices(object):
     """The group of connected devices.
+
     """
 
     def __init__(self):
@@ -371,7 +276,8 @@ class Devices(object):
         """
 
         if device.resource_name is not None:
-            raise ValueError('The device %r is already assigned to %s' % (device, device.resource_name))
+            msg = 'The device %r is already assigned to %s'
+            raise ValueError(msg % (device, device.resource_name))
 
         device.resource_name = resource_name
 
@@ -386,4 +292,3 @@ class Devices(object):
         :rtype: tuple[str]
         """
         return tuple(self._internal.keys())
-

--- a/pyvisa-sim/gpib.py
+++ b/pyvisa-sim/gpib.py
@@ -46,6 +46,7 @@ class GPIBInstrumentSession(sessions.Session):
 
             if not last:
                 time.sleep(.01)
+                now = time.time()
                 continue
 
             out += last

--- a/pyvisa-sim/highlevel.py
+++ b/pyvisa-sim/highlevel.py
@@ -12,6 +12,7 @@
 from __future__ import division, unicode_literals, print_function, absolute_import
 
 import random
+from traceback import format_exc
 
 from pyvisa import constants, highlevel, rname
 import pyvisa.errors as errors
@@ -63,7 +64,8 @@ class SimVisaLibrary(highlevel.VisaLibraryBase):
             else:
                 self.devices = parser.get_devices(self.library_path, False)
         except Exception as e:
-            raise Exception('Could not parse definitions file. %r' % e)
+            msg = 'Could not parse definitions file. %r'
+            raise type(e)(msg % format_exc())
 
     def _register(self, obj):
         """Creates a random but unique session handle for a session object,

--- a/pyvisa-sim/highlevel.py
+++ b/pyvisa-sim/highlevel.py
@@ -14,7 +14,7 @@ from __future__ import division, unicode_literals, print_function, absolute_impo
 import random
 
 from pyvisa import constants, highlevel, rname
-from pyvisa import errors
+import pyvisa.errors as errors
 from pyvisa.compat import OrderedDict
 
 from . import parser

--- a/pyvisa-sim/serial.py
+++ b/pyvisa-sim/serial.py
@@ -53,6 +53,7 @@ class SerialInstrumentSession(sessions.Session):
 
             if not last:
                 time.sleep(.01)
+                now = time.time()
                 continue
 
             out += last
@@ -109,4 +110,3 @@ class SerialInstrumentSession(sessions.Session):
 
             elif not asrl_end == constants.SerialTermination.none:
                 raise ValueError('Unknown value for VI_ATTR_ASRL_END_OUT')
-

--- a/pyvisa-sim/sessions.py
+++ b/pyvisa-sim/sessions.py
@@ -140,5 +140,3 @@ class Session(object):
             return constants.StatusCode.error_nonsupported_attribute_state
 
         return constants.StatusCode.success
-
-

--- a/pyvisa-sim/tcpip.py
+++ b/pyvisa-sim/tcpip.py
@@ -38,6 +38,7 @@ class BaseTCPIPSession(sessions.Session):
 
             if not last:
                 time.sleep(.01)
+                now = time.time()
                 continue
 
             out += last

--- a/pyvisa-sim/testsuite/channels.yaml
+++ b/pyvisa-sim/testsuite/channels.yaml
@@ -1,0 +1,107 @@
+spec: "1.1"
+devices:
+  device 1:
+    eom:
+      ASRL INSTR:
+        q: "\r\n"
+        r: "\n"
+      USB INSTR:
+        q: "\n"
+        r: "\n"
+      TCPIP INSTR:
+        q: "\n"
+        r: "\n"
+      GPIB INSTR:
+        q: "\n"
+        r: "\n"
+    error: ERROR
+    dialogues:
+      - q: "?IDN"
+        r: "LSG Serial #1234"
+    properties:
+      selected_channel:
+        default: 1
+        getter:
+          q: 'I?'
+          r: '{}'
+        setter:
+          q: 'I {}'
+    channels:
+      type1:
+        ids: [1, 2]
+        can_select: False
+        properties:
+          frequency:
+            default: 1.0
+            getter:
+              q: 'F?'
+              r: '{:.3f}'
+            setter:
+              q: 'F {:.3f}'
+            specs:
+              type: float
+              min: 1.0
+              max: 10.0
+
+  device 2:
+    eom:
+      ASRL INSTR:
+        q: "\r\n"
+        r: "\n"
+      USB INSTR:
+        q: "\n"
+        r: "\n"
+      TCPIP INSTR:
+        q: "\n"
+        r: "\n"
+      GPIB INSTR:
+        q: "\n"
+        r: "\n"
+    dialogues:
+      - q: "*IDN?"
+        r: "SCPI,MOCK,VERSION_1.0"
+    channels:
+      channel:
+        ids: [1, 2, 3]
+        can_select: True
+        properties:
+          voltage:
+            default: 1.0
+            getter:
+              q: "CH {ch_id}:VOLT:IMM:AMPL?"
+              r: "{:+.8E}"
+            setter:
+              q: "CH {ch_id}:VOLT:IMM:AMPL {:.3f}"
+            specs:
+              min: 1
+              max: 6
+              type: float
+          output_enabled:
+            default: 0
+            getter:
+              q: "CH {ch_id}:OUTP?"
+              r: "{:d}"
+            setter:
+              q: "CH {ch_id}:OUTP {:d}"
+            specs:
+              valid: [0, 1]
+              type: int
+
+
+resources:
+  ASRL1::INSTR:
+    device: device 1
+  USB::0x1111::0x2222::0x1234::INSTR:
+    device: device 1
+  TCPIP::localhost:1111::INSTR:
+    device: device 1
+  GPIB::8::INSTR:
+    device: device 1
+  ASRL2::INSTR:
+    device: device 2
+  USB::0x1111::0x2222::0x2468::INSTR:
+    device: device 2
+  TCPIP::localhost:2222::INSTR:
+    device: device 2
+  GPIB::9::INSTR:
+    device: device 2

--- a/pyvisa-sim/testsuite/test_channel.py
+++ b/pyvisa-sim/testsuite/test_channel.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*-
+
+import os
+
+from pyvisa.testsuite import BaseTestCase
+import visa
+
+PACKAGE = os.path.dirname(__file__)
+
+
+class TestChannels(BaseTestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        path = os.path.join(PACKAGE, 'channels.yaml')
+        cls.rm = visa.ResourceManager(path+'@sim')
+
+    def test_device_with_channel_preselection(self):
+        run_list = (
+            'GPIB0::8::65535::INSTR',
+            'TCPIP0::localhost:1111::inst0::INSTR',
+            'ASRL1::INSTR',
+            'USB0::0x1111::0x2222::0x1234::0::INSTR'
+            )
+        for rn in run_list:
+            self._test_device_with_channel_preselection(rn)
+
+    def test_device_with_inline_selection(self):
+        run_list = (
+            'ASRL2::INSTR',
+            'USB0::0x1111::0x2222::0x2468::0::INSTR',
+            'TCPIP0::localhost:2222::inst0::INSTR',
+            'GPIB0::9::65535::INSTR',
+            )
+        for rn in run_list:
+            self._test_device_with_inline_selection(rn)
+
+    def _test(self, inst, a, b):
+        query = inst.query(a)
+        self.assertEqual(query, b,
+                         msg=inst.resource_name + ', %r == %r' % (query, b))
+
+    def _test_device_with_channel_preselection(self, resource_name):
+        inst = self.rm.open_resource(resource_name, read_termination='\n',
+                                     write_termination='\r\n' if resource_name.startswith('ASRL') else '\n')
+        self._test(inst, 'I?', '1')
+
+        self._test(inst, 'F?', '1.000')
+        inst.write('F 5.0')
+        self._test(inst, 'F?', '5.000')
+        self._test(inst, 'I 2;F?', '1.000')
+
+        inst.close()
+
+    def _test_device_with_inline_selection(self, resource_name):
+        inst = self.rm.open_resource(
+            resource_name,
+            read_termination='\n',
+            write_termination='\r\n' if resource_name.startswith('ASRL') else '\n'
+            )
+
+        self._test(inst, "CH 1:VOLT:IMM:AMPL?", '+1.00000000E+00')
+        inst.write("CH 1:VOLT:IMM:AMPL 2.0")
+        self._test(inst, "CH 1:VOLT:IMM:AMPL?", '+2.00000000E+00')
+        self._test(inst, "CH 2:VOLT:IMM:AMPL?", '+1.00000000E+00')

--- a/pyvisa-sim/usb.py
+++ b/pyvisa-sim/usb.py
@@ -51,6 +51,7 @@ class USBInstrumentSession(sessions.Session):
 
             if not last:
                 time.sleep(.01)
+                now = time.time()
                 continue
 
             out += last


### PR DESCRIPTION
This adds a 'channels' keyword to the parser. When declaring channel, for each channel one can declare the active ids ('ids') (which can be altered in the resource), whether or not the channel can be selected from within a command ('can_select') (ie Ch 1:VOLT:IMM is supported).
If a device property can be used to select a channel it should be declared under the name 'select_channel'.
This also adds support for concatenating multiple commands separated by a special character (';' by default and can be specified by declaring a 'delimiter' field.
I also re-factored some things I needed in channel away from devices, they are now in component.py

I added some very basic tests also.

This is ready for review from my point of view. I will try to prepare another PR for sending error messages to an error queue and declare a dialog to query the last error.