### PR TITLE
fix: Allowed channel properties to omit getter/setter

### DIFF
--- a/pyvisa-sim/channels.py
+++ b/pyvisa-sim/channels.py
@@ -111,14 +111,16 @@ class Channels(Component):
         self._properties[name] = ChannelProperty(self, name,
                                                  default_value, specs)
 
-        query, response = getter_pair
-        self._getters['__default__'][to_bytes(query)] = name, response
+        if getter_pair:
+            query, response = getter_pair
+            self._getters['__default__'][to_bytes(query)] = name, response
 
-        query, response, error = setter_triplet
-        self._setters.append((name,
-                              stringparser.Parser(query),
-                              to_bytes(response),
-                              to_bytes(error)))
+        if setter_triplet:
+            query, response, error = setter_triplet
+            self._setters.append((name,
+                                  stringparser.Parser(query),
+                                  to_bytes(response),
+                                  to_bytes(error)))
 
     def match(self, query):
         """Try to find a match for a query in the channel commands.


### PR DESCRIPTION
Channel properties did not allow the user to omit setting a
getter or setter and required both to be set. Change makes channel
properties consistent with global properties.